### PR TITLE
Add support for test files that match the pattern **/*Tests.java.

### DIFF
--- a/junit5-maven-consumer/README.md
+++ b/junit5-maven-consumer/README.md
@@ -7,9 +7,9 @@ executed in the same run.
 ## Executing JUnit 4 and JUnit 5 Tests
 
 Invoking `mvn clean test` from the command line will execute all tests in the test source
-folder that follow one of
-[Surefire's default naming patterns](http://maven.apache.org/surefire/maven-surefire-plugin/examples/inclusion-exclusion.html)
-(`Test*`, `*Test`, or `*TestCase`), resulting in output similar to the following:
+folder that follow one of following patterns: `Test*`, `*Test`, `*Tests` or `*TestCase`.
+Note that [Surefire's default naming patterns](http://maven.apache.org/surefire/maven-surefire-plugin/examples/inclusion-exclusion.html) have been overridden in the pom.xml file.  Surefire's execution of
+the sample tests should result in output similar to the following:
 
 ```
 -------------------------------------------------------
@@ -17,6 +17,8 @@ folder that follow one of
 -------------------------------------------------------
 Running com.example.project.FirstTest
 Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.073 sec - in com.example.project.FirstTest
+Running com.example.project.OtherTests
+Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in com.example.project.OtherTests
 Running com.example.project.JUnit4Test
 Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.015 sec - in com.example.project.JUnit4Test
 Running com.example.project.SecondTest

--- a/junit5-maven-consumer/pom.xml
+++ b/junit5-maven-consumer/pom.xml
@@ -59,6 +59,14 @@
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.19</version>
+				<configuration>
+					<includes>
+						<include>**/Test*.java</include>
+						<include>**/*Test.java</include>
+						<include>**/*Tests.java</include>
+						<include>**/*TestCase.java</include>
+					</includes>
+				</configuration>
 				<dependencies>
 					<dependency>
 						<groupId>org.junit.platform</groupId>

--- a/junit5-maven-consumer/src/test/java/com/example/project/OtherTests.java
+++ b/junit5-maven-consumer/src/test/java/com/example/project/OtherTests.java
@@ -1,0 +1,18 @@
+
+package com.example.project;
+
+import org.junit.jupiter.api.Test;
+
+public class OtherTests {
+
+	@Test
+	public void testThisThing() {
+
+	}
+
+	@Test
+	public void testThisOtherThing() {
+
+	}
+
+}


### PR DESCRIPTION
I had a couple projects that ran tests just fine within Eclipse but didn't find any when run via Maven.  Then I realized that the non-functional projects all used the JUnit5 test class naming conventions.  The configuration block in the Maven POM supports the original patterns in addition to the JUnit 5 pattern so that vintage and jupiter tests can both be run during a Maven build.