### PR TITLE
Alters POM to minimize test-compile dependencies

### DIFF
--- a/junit5-maven-consumer/pom.xml
+++ b/junit5-maven-consumer/pom.xml
@@ -11,8 +11,9 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
+		<junit.version>4.12</junit.version>
 		<junit.jupiter.version>5.0.0-M2</junit.jupiter.version>
-		<junit.vintage.version>4.12.0-M2</junit.vintage.version>
+		<junit.vintage.version>${junit.version}.0-M2</junit.vintage.version>
 		<junit.platform.version>1.0.0-M2</junit.platform.version>
 	</properties>
 
@@ -43,6 +44,16 @@
 						<artifactId>junit-platform-surefire-provider</artifactId>
 						<version>${junit.platform.version}</version>
 					</dependency>
+					<dependency>
+						<groupId>org.junit.jupiter</groupId>
+						<artifactId>junit-jupiter-engine</artifactId>
+						<version>${junit.jupiter.version}</version>
+					</dependency>
+					<dependency>
+						<groupId>org.junit.vintage</groupId>
+						<artifactId>junit-vintage-engine</artifactId>
+						<version>${junit.vintage.version}</version>
+					</dependency>
 				</dependencies>
 			</plugin>
 		</plugins>
@@ -51,14 +62,14 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
+			<artifactId>junit-jupiter-api</artifactId>
 			<version>${junit.jupiter.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
-			<version>${junit.vintage.version}</version>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
## Overview

JUnit 5 has separated the public facing APIs from the runner, engines, launcher and console in an effort to keep test writers from using non-public classes when writing their tests.  The existing Maven POM file adds dependencies these non-public classes to the test-compile scope which allows users to accidentally become dependent on these non-public classes.  The test-compile dependency hierarchy in the existing POM is as follows:

![junit5-maven-consumer-dependencies](https://cloud.githubusercontent.com/assets/328333/18360679/f0195c2e-75cc-11e6-97b2-0688a2c2161f.png)

This pull request alters the POM file so that the JUnit 5 classes exposed to the test writer are minimized.  Since the runner and engine classes (and their dependencies) are required during test execution, these dependencies are instead added to the classpath when the maven-surefire-plugin is executed.  After this change, the test-compile dependency hierarchy in the POM is as follows:

![junit5-maven-consumer-minimal-dependencies](https://cloud.githubusercontent.com/assets/328333/18360758/482ecf0c-75cd-11e6-9763-0a9617f89663.png)

The results of running ```mvn clean test``` is unchanged, so the README file is still accurate.

---
I hereby agree to the terms of the JUnit Contributor License Agreement.

