### PR TITLE
Add missing junit-jupiter-engine dependency to be able to run junit5-maven-consumer in IntelliJ IDEA

### DIFF
--- a/junit5-maven-consumer/pom.xml
+++ b/junit5-maven-consumer/pom.xml
@@ -71,6 +71,12 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>${junit.jupiter.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>${junit.version}</version>


### PR DESCRIPTION
Add missing junit-jupiter-engine dependency to be able to run junit5-maven-consumer in IntelliJ IDEA

## Overview

-

---
I hereby agree to the terms of the JUnit Contributor License Agreement.
