### PR TITLE
Upgrade maven-surefire-plugin version to 2.20.1

### DIFF
--- a/junit5-maven-consumer/pom.xml
+++ b/junit5-maven-consumer/pom.xml
@@ -29,14 +29,8 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.19.1</version>
+				<version>2.20.1</version>
 				<configuration>
-					<includes>
-						<include>**/Test*.java</include>
-						<include>**/*Test.java</include>
-						<include>**/*Tests.java</include>
-						<include>**/*TestCase.java</include>
-					</includes>
 					<properties>
 						<!-- <includeTags>fast</includeTags> -->
 						<excludeTags>slow</excludeTags>


### PR DESCRIPTION
See gh-23

## Overview

- Upgrade `maven-surefire-plugin` version and remove `includes` in `configuration` section since the plugin provides `**/*Tests.java`

---
I hereby agree to the terms of the JUnit Contributor License Agreement.
