### PR TITLE
Add travisci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: java
+sudo: false
+
+jdk:
+  - oraclejdk8
+
+os:
+  - linux
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+    - $HOME/.m2
+
+jobs:
+  include:
+    - stage: junit5-maven-consumer
+      script: cd $TRAVIS_BUILD_DIR/junit5-maven-consumer && ./mvnw clean test
+    - stage: junit5-gradle-consumer
+      script: cd $TRAVIS_BUILD_DIR/junit5-gradle-consumer &&./gradlew clean test
+    - stage: junit5-mockito-extension
+      script: cd $TRAVIS_BUILD_DIR/junit5-mockito-extension &&./gradlew clean test


### PR DESCRIPTION
See gh-17

## Overview

- Add integration with `travisci` using two stages, one for `maven` and the other for `gradle`.  Taking advantage of stages, in the case of gradle there are two projects which can run in parallel.

<img width="943" alt="screen shot 2017-06-19 at 8 55 12 pm" src="https://user-images.githubusercontent.com/1810547/27313076-a039fffc-5531-11e7-9227-a264eb73f169.png">


---
I hereby agree to the terms of the JUnit Contributor License Agreement.
