### PR TITLE
Part III - Add junit5-vanilla-java9 sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ gradle-app.setting
 
 # IntelliJ
 .idea
+out/
 *.iml
 *.ipr
 *.iws

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,6 @@ jobs:
     - stage: junit5-java9-engine
       jdk: oraclejdk9
       script: cd $TRAVIS_BUILD_DIR/junit5-java9-engine && ./gradlew --console plain test
+    - stage: junit5-vanilla-java9
+      jdk: oraclejdk9
+      script: cd $TRAVIS_BUILD_DIR/junit5-vanilla-java9 && ./build.jsh

--- a/junit5-vanilla-java9/.gitignore
+++ b/junit5-vanilla-java9/.gitignore
@@ -1,0 +1,3 @@
+deps/
+mods/
+!src/build

--- a/junit5-vanilla-java9/LICENSE.md
+++ b/junit5-vanilla-java9/LICENSE.md
@@ -1,0 +1,98 @@
+Eclipse Public License - v 2.0
+==============================
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICENSE (“AGREEMENT”). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+### 1. Definitions
+
+“Contribution” means:
+* **a)** in the case of the initial Contributor, the initial content Distributed under this Agreement, and
+* **b)** in the case of each subsequent Contributor:
+	* **i)** changes to the Program, and
+	* **ii)** additions to the Program;
+where such changes and/or additions to the Program originate from and are Distributed by that particular Contributor. A Contribution “originates” from a Contributor if it was added to the Program by such Contributor itself or anyone acting on such Contributor's behalf. Contributions do not include changes or additions to the Program that are not Modified Works.
+
+“Contributor” means any person or entity that Distributes the Program.
+
+“Licensed Patents” mean patent claims licensable by a Contributor which are necessarily infringed by the use or sale of its Contribution alone or when combined with the Program.
+
+“Program” means the Contributions Distributed in accordance with this Agreement.
+
+“Recipient” means anyone who receives the Program under this Agreement or any Secondary License (as applicable), including Contributors.
+
+“Derivative Works” shall mean any work, whether in Source Code or other form, that is based on (or derived from) the Program and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship.
+
+“Modified Works” shall mean any work in Source Code or other form that results from an addition to, deletion from, or modification of the contents of the Program, including, for purposes of clarity any new file in Source Code form that contains any contents of the Program. Modified Works shall not include works that contain only declarations, interfaces, types, classes, structures, or files of the Program solely in each case in order to link to, bind by name, or subclass the Program or Modified Works thereof.
+
+“Distribute” means the acts of **a)** distributing or **b)** making available in any manner that enables the transfer of a copy.
+
+“Source Code” means the form of a Program preferred for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+“Secondary License” means either the GNU General Public License, Version 2.0, or any later versions of that license, including any exceptions or additional permissions as identified by the initial Contributor.
+
+### 2. Grant of Rights
+
+**a)** Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, Distribute and sublicense the Contribution of such Contributor, if any, and such Derivative Works.
+
+**b)** Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free patent license under Licensed Patents to make, use, sell, offer to sell, import and otherwise transfer the Contribution of such Contributor, if any, in Source Code or other form. This patent license shall apply to the combination of the Contribution and the Program if, at the time the Contribution is added by the Contributor, such addition of the Contribution causes such combination to be covered by the Licensed Patents. The patent license shall not apply to any other combinations which include the Contribution. No hardware per se is licensed hereunder.
+
+**c)** Recipient understands that although each Contributor grants the licenses to its Contributions set forth herein, no assurances are provided by any Contributor that the Program does not infringe the patent or other intellectual property rights of any other entity. Each Contributor disclaims any liability to Recipient for claims brought by any other entity based on infringement of intellectual property rights or otherwise. As a condition to exercising the rights and licenses granted hereunder, each Recipient hereby assumes sole responsibility to secure any other intellectual property rights needed, if any. For example, if a third party patent license is required to allow Recipient to Distribute the Program, it is Recipient's responsibility to acquire that license before distributing the Program.
+
+**d)** Each Contributor represents that to its knowledge it has sufficient copyright rights in its Contribution, if any, to grant the copyright license set forth in this Agreement.
+
+**e)** Notwithstanding the terms of any Secondary License, no Contributor makes additional grants to any Recipient (other than those set forth in this Agreement) as a result of such Recipient's receipt of the Program under the terms of a Secondary License (if permitted under the terms of Section 3).
+
+### 3. Requirements
+
+**3.1** If a Contributor Distributes the Program in any form, then:
+
+* **a)** the Program must also be made available as Source Code, in accordance with section 3.2, and the Contributor must accompany the Program with a statement that the Source Code for the Program is available under this Agreement, and informs Recipients how to obtain it in a reasonable manner on or through a medium customarily used for software exchange; and
+
+* **b)** the Contributor may Distribute the Program under a license different than this Agreement, provided that such license:
+	* **i)** effectively disclaims on behalf of all other Contributors all warranties and conditions, express and implied, including warranties or conditions of title and non-infringement, and implied warranties or conditions of merchantability and fitness for a particular purpose;
+	* **ii)** effectively excludes on behalf of all other Contributors all liability for damages, including direct, indirect, special, incidental and consequential damages, such as lost profits;
+	* **iii)** does not attempt to limit or alter the recipients' rights in the Source Code under section 3.2; and
+	* **iv)** requires any subsequent distribution of the Program by any party to be under a license that satisfies the requirements of this section 3.
+
+**3.2** When the Program is Distributed as Source Code:
+
+* **a)** it must be made available under this Agreement, or if the Program **(i)** is combined with other material in a separate file or files made available under a Secondary License, and **(ii)** the initial Contributor attached to the Source Code the notice described in Exhibit A of this Agreement, then the Program may be made available under the terms of such Secondary Licenses, and
+* **b)** a copy of this Agreement must be included with each copy of the Program.
+
+**3.3** Contributors may not remove or alter any copyright, patent, trademark, attribution notices, disclaimers of warranty, or limitations of liability (“notices”) contained within the Program from any copy of the Program which they Distribute, provided that Contributors may add their own appropriate notices.
+
+### 4. Commercial Distribution
+
+Commercial distributors of software may accept certain responsibilities with respect to end users, business partners and the like. While this license is intended to facilitate the commercial use of the Program, the Contributor who includes the Program in a commercial product offering should do so in a manner which does not create potential liability for other Contributors. Therefore, if a Contributor includes the Program in a commercial product offering, such Contributor (“Commercial Contributor”) hereby agrees to defend and indemnify every other Contributor (“Indemnified Contributor”) against any losses, damages and costs (collectively “Losses”) arising from claims, lawsuits and other legal actions brought by a third party against the Indemnified Contributor to the extent caused by the acts or omissions of such Commercial Contributor in connection with its distribution of the Program in a commercial product offering. The obligations in this section do not apply to any claims or Losses relating to any actual or alleged intellectual property infringement. In order to qualify, an Indemnified Contributor must: **a)** promptly notify the Commercial Contributor in writing of such claim, and **b)** allow the Commercial Contributor to control, and cooperate with the Commercial Contributor in, the defense and any related settlement negotiations. The Indemnified Contributor may participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial product offering, Product X. That Contributor is then a Commercial Contributor. If that Commercial Contributor then makes performance claims, or offers warranties related to Product X, those performance claims and warranties are such Commercial Contributor's responsibility alone. Under this section, the Commercial Contributor would have to defend claims against the other Contributors related to those performance claims and warranties, and if a court requires any other Contributor to pay any damages as a result, the Commercial Contributor must pay those damages.
+
+### 5. No Warranty
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the appropriateness of using and distributing the Program and assumes all risks associated with its exercise of rights under this Agreement, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and unavailability or interruption of operations.
+
+### 6. Disclaimer of Liability
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+### 7. General
+
+If any provision of this Agreement is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this Agreement, and without further action by the parties hereto, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Program itself (excluding combinations of the Program with other software or hardware) infringes such Recipient's patent(s), then such Recipient's rights granted under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to comply with any of the material terms or conditions of this Agreement and does not cure such failure in a reasonable period of time after becoming aware of such noncompliance. If all Recipient's rights under this Agreement terminate, Recipient agrees to cease use and distribution of the Program as soon as reasonably practicable. However, Recipient's obligations under this Agreement and any licenses granted by Recipient relating to the Program shall continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in order to avoid inconsistency the Agreement is copyrighted and may only be modified in the following manner. The Agreement Steward reserves the right to publish new versions (including revisions) of this Agreement from time to time. No one other than the Agreement Steward has the right to modify this Agreement. The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation may assign the responsibility to serve as the Agreement Steward to a suitable separate entity. Each new version of the Agreement will be given a distinguishing version number. The Program (including Contributions) may always be Distributed subject to the version of the Agreement under which it was received. In addition, after a new version of the Agreement is published, Contributor may elect to Distribute the Program (including its Contributions) under the new version.
+
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives no rights or licenses to the intellectual property of any Contributor under this Agreement, whether expressly, by implication, estoppel or otherwise. All rights in the Program not expressly granted under this Agreement are reserved. Nothing in this Agreement is intended to be enforceable by any entity that is not a Contributor or Recipient. No third-party beneficiary rights are created under this Agreement.
+
+#### Exhibit A - Form of Secondary Licenses Notice
+
+> “This Source Code may also be made available under the following Secondary Licenses when the conditions for such availability set forth in the Eclipse Public License, v. 2.0 are satisfied: {name license(s), version(s), and exceptions or additional permissions here}.”
+
+Simply including a copy of this Agreement, including this Exhibit A is not sufficient to license the Source Code under Secondary Licenses.
+
+If it is not possible or desirable to put the notice in a particular file, then You may include the notice in a location (such as a LICENSE file in a relevant directory) where a recipient would be likely to look for such a notice.
+
+You may add additional accurate notices of copyright ownership.

--- a/junit5-vanilla-java9/README.md
+++ b/junit5-vanilla-java9/README.md
@@ -1,0 +1,106 @@
+# junit5-vanilla-java9
+
+The `junit5-vanilla-java9` project demonstrates how to execute JUnit Jupiter
+tests on the module-path.
+Be sure to consult the
+[Quick-Start Guide](http://openjdk.java.net/projects/jigsaw/quick-start)
+describing the Jigsaw Module System first.
+
+
+## JShell as Build Tool
+
+There's **no** external build tool involved. The pojo `Build.java` stored in
+`src/build` directory is sourced into a JShell session by the `build.jsh` script.
+`Build.java` uses default JDK Tool provisioning to compile and launch test runs
+in a platform-independent manner.
+
+Either start the sample via `jshell build.jsh` or mount the `src/build` as a
+source directory within your IDE and "press play on tape", i.e. run main method
+of class `Build`.
+
+
+## Directory Layout and Build Commands
+
+### **`deps`**
+
+The `deps` directory contains all modules this sample project depends on.
+If it does not exist `Build` creates and fills it with resolved jar files.
+ 
+
+### **`src/main`**
+The `src/main` directory contains the sources of a sample library and an
+application that uses/reads/requires the exported api of the library:
+```
+└─ src/main
+   ├─ com.example.project
+   └─ org.example.library
+```
+
+Compile main module `com.example.project`:
+```
+javac
+  -d mods/main
+  --module-path deps
+  --module-source-path src/main
+  --module com.example.project
+```
+
+### **`src/test`**
+The `src/test` directory contains the sources for testing the library
+and application module -- legacy style.
+Strong module boundaries are lifted by patching in main module sources.
+Note how the same module names are used as in the main source directory:
+```
+└─ src/test
+   ├─ com.example.project
+   └─ org.example.library
+```
+
+Compile test module `com.example.project`:
+```
+javac
+  -d mods/test
+  --module-path mods/main:deps
+  --module-source-path src/test
+  --patch-module com.example.project=src/main/com.example.project
+  --module com.example.project
+```
+
+Run all tests that can be found on the module-path:
+```
+java 
+  --module-path mods/test:mods/main:deps
+  --add-modules ALL-MODULE-PATH
+  --module org.junit.platform.console
+  --scan-module-path
+╷
+└─ JUnit Jupiter ✔
+   ├─ CalculatorTests ✔
+   │  └─ JUnit 5 test! ✔
+   └─ ProtectedVersionTests ✔
+      └─ versionEquals4711() ✔
+```
+
+### **`src/user`**
+Contains the sources for testing the library and application -- from an
+end-user point-of-view. The tests are only able to see and use the exported
+parts of the main modules.
+```
+└─ src/user
+   └─ integration
+```
+
+Run all tests that can be found on the module-path:
+```
+java
+  --module-path mods/user:mods/main:deps
+  --add-modules ALL-MODULE-PATH
+  --module org.junit.platform.console
+  --scan-module-path
+╷
+└─ JUnit Jupiter ✔
+   └─ IntegrationTests ✔
+      ├─ projectIsAccessable() ✔
+      ├─ explicitModuleNames() ✔
+      └─ libraryIsAccessable() ✔
+```

--- a/junit5-vanilla-java9/build.jsh
+++ b/junit5-vanilla-java9/build.jsh
@@ -1,0 +1,7 @@
+//usr/bin/env jshell --show-version --execution local "$0" "$@"; exit $?
+
+/open src/build/Build.java
+
+Build.main()
+
+/exit

--- a/junit5-vanilla-java9/logging.properties
+++ b/junit5-vanilla-java9/logging.properties
@@ -1,0 +1,3 @@
+.level=FINE
+handlers=java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.level=FINE

--- a/junit5-vanilla-java9/src/build/Build.java
+++ b/junit5-vanilla-java9/src/build/Build.java
@@ -112,7 +112,7 @@ class Build {
     args.add("--module-path").add(modulePath);
     args.add("--add-modules").add("ALL-MODULE-PATH");
     args.add("--module").add("org.junit.platform.console");
-    args.add("--scan-module-path");
+    args.add("--scan-class-path"); // TODO replace with "--scan-module-path"
     Util.run("java", args.list);
   }
 
@@ -123,18 +123,15 @@ class Build {
     String version = "1.0.0";
     resolve(repository + "org/apiguardian", "apiguardian-api", version);
     resolve(repository + "org/opentest4j", "opentest4j", version);
-    // branch "module", PR #1061
+    // branch "jigsaw"
     repository = "https://jitpack.io/com/github/junit-team/junit5/";
-    version = "module-r5.0.0-gb2081d7-20";
+    version = "jigsaw-r5.0.0-gbe104bb-69";
     resolve(repository, "junit-jupiter-api", version);
     resolve(repository, "junit-jupiter-engine", version);
     resolve(repository, "junit-platform-commons", version);
     resolve(repository, "junit-platform-console", version);
     resolve(repository, "junit-platform-engine", version);
     resolve(repository, "junit-platform-launcher", version);
-    // branch "jpms", PR #1057
-    version = "jpms-r5.0.0-geba6164-19";
-    resolve(repository, "junit-platform-commons-jpms", version);
   }
 
   /** Resolve dependency by downloading the associated jar file for the given coordinates. */

--- a/junit5-vanilla-java9/src/build/Build.java
+++ b/junit5-vanilla-java9/src/build/Build.java
@@ -1,0 +1,259 @@
+// unnamed package
+
+import static java.util.stream.Collectors.toList;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Logger;
+import java.util.spi.ToolProvider;
+import java.util.stream.Stream;
+
+@SuppressWarnings("ALL")
+class Build {
+
+  Path deps = Paths.get("deps");
+
+  Path src = Paths.get("src");
+  Path mods = Paths.get("mods");
+  Path mainSource = src.resolve("main");
+  Path mainTarget = mods.resolve("main");
+  Path testSource = src.resolve("test");
+  Path testTarget = mods.resolve("test");
+  Path userSource = src.resolve("user");
+  Path userTarget = mods.resolve("user");
+
+  void build() {
+    clean();
+    resolve();
+    compileMain();
+    compileTest();
+    compileUser();
+    test();
+  }
+
+  void clean() {
+    Util.log.info("Clean output directories");
+    Util.clean(mods);
+  }
+
+  void compileMain() {
+    Util.log.info("Compile main application modules");
+    Util.findDirectoryNames(mainSource).forEach(this::compileMain);
+  }
+
+  void compileMain(String module) {
+    Args args = new Args();
+    args.add("-d").add(mainTarget);
+    args.add("--module-path").add(deps);
+    args.add("--module-source-path").add(mainSource);
+    args.add("--module").add(module);
+    Util.run("javac", args.list);
+  }
+
+  void compileTest() {
+    Util.log.info("Compile test application modules");
+    Util.findDirectoryNames(testSource).forEach(this::compileTest);
+  }
+
+  void compileTest(String module) {
+    Args args = new Args();
+    args.add("-d").add(testTarget);
+    args.add("--module-path").add(mainTarget, deps);
+    args.add("--module-source-path").add(testSource);
+    args.add("--patch-module").add(module + "=" + mainSource.resolve(module));
+    args.add("--module").add(module);
+    Util.run("javac", args.list);
+  }
+
+  void compileUser() {
+    Util.log.info("Compile user-view test integration modules");
+    Util.findDirectoryNames(userSource).forEach(this::compileUser);
+  }
+
+  void compileUser(String module) {
+    Args args = new Args();
+    args.add("-d").add(userTarget);
+    args.add("--module-path").add(mainTarget, deps);
+    args.add("--module-source-path").add(userSource);
+    args.add("--module").add(module);
+    Util.run("javac", args.list);
+  }
+
+  void test() {
+    Util.log.info("Launch test runs");
+    test(testTarget, mainTarget, deps);
+    test(userTarget, mainTarget, deps);
+  }
+
+  void test(Path... modulePath) {
+    Args args = new Args();
+    args.add("--module-path").add(modulePath);
+    args.add("--add-modules").add("ALL-MODULE-PATH");
+    args.add("--module").add("org.junit.platform.console");
+    args.add("--scan-module-path");
+    Util.run("java", args.list);
+  }
+
+  /** Resolve all external dependencies. */
+  void resolve() {
+    Util.log.info("Resolve dependencies");
+    String repository = "http://central.maven.org/maven2/";
+    String version = "1.0.0";
+    resolve(repository + "org/apiguardian", "apiguardian-api", version);
+    resolve(repository + "org/opentest4j", "opentest4j", version);
+    // branch "module", PR #1061
+    repository = "https://jitpack.io/com/github/junit-team/junit5/";
+    version = "module-r5.0.0-gb2081d7-20";
+    resolve(repository, "junit-jupiter-api", version);
+    resolve(repository, "junit-jupiter-engine", version);
+    resolve(repository, "junit-platform-commons", version);
+    resolve(repository, "junit-platform-console", version);
+    resolve(repository, "junit-platform-engine", version);
+    resolve(repository, "junit-platform-launcher", version);
+    // branch "jpms", PR #1057
+    version = "jpms-r5.0.0-geba6164-19";
+    resolve(repository, "junit-platform-commons-jpms", version);
+  }
+
+  /** Resolve dependency by downloading the associated jar file for the given coordinates. */
+  Path resolve(String base, String artifact, String version) {
+    String file = artifact + "-" + version + ".jar";
+    String uri = String.join("/", base, artifact, version, file);
+    return Util.download(URI.create(uri), deps);
+  }
+
+  /** Entry-point for building... */
+  public static void main(String... args) {
+    Util.log.info("BEGIN");
+    new Build().build();
+    Util.log.info("END.");
+  }
+
+  /** Command line option builder. */
+  class Args {
+    List<String> list = new ArrayList<>();
+
+    Args add(Object arg) {
+      list.add(arg.toString());
+      return this;
+    }
+
+    Args add(Path... paths) {
+      String delimiter = File.pathSeparator;
+      Stream<Path> stream = Arrays.stream(paths);
+      list.add(String.join(delimiter, stream.map(Object::toString).collect(toList())));
+      return this;
+    }
+  }
+
+  /** Static helpers. */
+  interface Util {
+
+    Logger log = Logger.getLogger("junit5-vanilla-java9");
+
+    /** Delete all files and directories from the root directory. */
+    static void clean(Path root) {
+      if (Files.notExists(root)) {
+        return;
+      }
+      try {
+        try (Stream<Path> stream = Files.walk(root)) {
+          Stream<Path> selected = stream.sorted((p, q) -> -p.compareTo(q));
+          for (Path path : selected.collect(toList())) {
+            Files.deleteIfExists(path);
+          }
+        }
+      } catch (IOException e) {
+        throw new UncheckedIOException("clean failed for: " + root, e);
+      }
+    }
+
+    /** Download the specified resource into the target directory. */
+    static Path download(URI uri, Path directory) {
+      String fileName = uri.getPath();
+      int begin = fileName.lastIndexOf('/') + 1;
+      fileName = fileName.substring(begin).split("\\?")[0].split("#")[0];
+      try {
+        URL url = uri.toURL();
+        Files.createDirectories(directory);
+        Path target = directory.resolve(fileName);
+        if (Files.exists(target)) {
+          return target;
+        }
+        try (InputStream sourceStream = url.openStream();
+            OutputStream targetStream = Files.newOutputStream(target)) {
+          System.out.println("Loading " + fileName + " from " + url.getHost() + "...");
+          sourceStream.transferTo(targetStream);
+        }
+        return target;
+      } catch (IOException e) {
+        throw new UncheckedIOException("download failed for: " + uri, e);
+      }
+    }
+
+    static List<Path> findDirectories(Path root) {
+      if (Files.notExists(root)) {
+        return List.of();
+      }
+      try (Stream<Path> paths = Files.find(root, 1, (path, attr) -> Files.isDirectory(path))) {
+        return paths.filter(path -> !root.equals(path)).collect(toList());
+      } catch (IOException e) {
+        throw new UncheckedIOException("find directories failed for: " + root, e);
+      }
+    }
+
+    static List<String> findDirectoryNames(Path root) {
+      return findDirectories(root)
+          .stream()
+          .map(root::relativize)
+          .map(Path::toString)
+          .collect(toList());
+    }
+
+    /** Run an internal or external tool with the supplied arguments. */
+    static void run(String name, Object... args) {
+      List<String> strings = new ArrayList<>();
+      Arrays.stream(args).map(Object::toString).forEach(strings::add);
+      run(name, strings);
+    }
+
+    /** Run an internal or external tool with the supplied arguments. */
+    static void run(String name, List<String> args) {
+      int result;
+      System.out.println(name + " " + args);
+      PrintStream standardOut = System.out;
+      PrintStream standardErr = System.err;
+      ToolProvider tool = ToolProvider.findFirst(name).orElse(null);
+      if (tool != null) {
+        String[] strings = args.toArray(new String[args.size()]);
+        result = tool.run(standardOut, standardErr, strings);
+      } else {
+        ProcessBuilder processBuilder = new ProcessBuilder(name);
+        processBuilder.command().addAll(args);
+        processBuilder.redirectErrorStream(true);
+        try {
+          Process process = processBuilder.start();
+          process.getInputStream().transferTo(standardOut);
+          result = process.waitFor();
+        } catch (IOException | InterruptedException e) {
+          throw new Error("process `" + name + "` failed", e);
+        }
+      }
+      if (result != 0) {
+        throw new RuntimeException(name + " failed with error code " + result);
+      }
+    }
+  }
+}

--- a/junit5-vanilla-java9/src/build/Build.java
+++ b/junit5-vanilla-java9/src/build/Build.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
 // unnamed package
 
 import static java.util.stream.Collectors.toList;

--- a/junit5-vanilla-java9/src/build/Build.java
+++ b/junit5-vanilla-java9/src/build/Build.java
@@ -112,7 +112,7 @@ class Build {
                     args.add("--patch-module").add(module + "=" + mainTarget.resolve(module)));
     */
     args.add("--module").add("org.junit.platform.console");
-    args.add("--select-module").add("ALL-MODULES");
+    args.add("--scan-module-path"); // short-cut for add("--select-module").add("ALL-MODULES")
     Util.run("java", args.list);
   }
 
@@ -125,7 +125,7 @@ class Build {
     resolve(repository + "org/opentest4j", "opentest4j", version);
     // branch "jigsaw"
     repository = "https://jitpack.io/com/github/junit-team/junit5/";
-    version = "jigsaw-r5.0.0-gc1e1af8-73";
+    version = "jigsaw-r5.0.0-g8580457-74";
     resolve(repository, "junit-jupiter-api", version);
     resolve(repository, "junit-jupiter-engine", version);
     resolve(repository, "junit-platform-commons", version);

--- a/junit5-vanilla-java9/src/build/Build.java
+++ b/junit5-vanilla-java9/src/build/Build.java
@@ -125,7 +125,7 @@ class Build {
     resolve(repository + "org/opentest4j", "opentest4j", version);
     // branch "jigsaw"
     repository = "https://jitpack.io/com/github/junit-team/junit5/";
-    version = "jigsaw-r5.0.0-g8580457-74";
+    version = "jigsaw-r5.0.0-g8581c50-96";
     resolve(repository, "junit-jupiter-api", version);
     resolve(repository, "junit-jupiter-engine", version);
     resolve(repository, "junit-platform-commons", version);

--- a/junit5-vanilla-java9/src/main/com.example.project/com/example/project/Calculator.java
+++ b/junit5-vanilla-java9/src/main/com.example.project/com/example/project/Calculator.java
@@ -1,0 +1,8 @@
+package com.example.project;
+
+public class Calculator {
+
+  public int add(int a, int b) {
+    return a + b;
+  }
+}

--- a/junit5-vanilla-java9/src/main/com.example.project/com/example/project/Calculator.java
+++ b/junit5-vanilla-java9/src/main/com.example.project/com/example/project/Calculator.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
 package com.example.project;
 
 public class Calculator {

--- a/junit5-vanilla-java9/src/main/com.example.project/com/example/project/api/Project.java
+++ b/junit5-vanilla-java9/src/main/com.example.project/com/example/project/api/Project.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
 package com.example.project.api;
 
 public class Project {

--- a/junit5-vanilla-java9/src/main/com.example.project/com/example/project/api/Project.java
+++ b/junit5-vanilla-java9/src/main/com.example.project/com/example/project/api/Project.java
@@ -1,0 +1,9 @@
+package com.example.project.api;
+
+public class Project {
+
+    public String getVersion() {
+        return ProtectedVersion.VERSION;
+    }
+
+}

--- a/junit5-vanilla-java9/src/main/com.example.project/com/example/project/api/ProtectedVersion.java
+++ b/junit5-vanilla-java9/src/main/com.example.project/com/example/project/api/ProtectedVersion.java
@@ -1,0 +1,5 @@
+package com.example.project.api;
+
+interface ProtectedVersion {
+    String VERSION = "47.11";
+}

--- a/junit5-vanilla-java9/src/main/com.example.project/com/example/project/api/ProtectedVersion.java
+++ b/junit5-vanilla-java9/src/main/com.example.project/com/example/project/api/ProtectedVersion.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
 package com.example.project.api;
 
 interface ProtectedVersion {

--- a/junit5-vanilla-java9/src/main/com.example.project/module-info.java
+++ b/junit5-vanilla-java9/src/main/com.example.project/module-info.java
@@ -1,0 +1,5 @@
+module com.example.project {
+  requires org.example.library;
+
+  exports com.example.project.api;
+}

--- a/junit5-vanilla-java9/src/main/com.example.project/module-info.java
+++ b/junit5-vanilla-java9/src/main/com.example.project/module-info.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
 module com.example.project {
   requires org.example.library;
 

--- a/junit5-vanilla-java9/src/main/org.example.library/module-info.java
+++ b/junit5-vanilla-java9/src/main/org.example.library/module-info.java
@@ -1,0 +1,3 @@
+module org.example.library {
+  exports org.example.library;
+}

--- a/junit5-vanilla-java9/src/main/org.example.library/module-info.java
+++ b/junit5-vanilla-java9/src/main/org.example.library/module-info.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
 module org.example.library {
   exports org.example.library;
 }

--- a/junit5-vanilla-java9/src/main/org.example.library/org/example/library/Library.java
+++ b/junit5-vanilla-java9/src/main/org.example.library/org/example/library/Library.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
 package org.example.library;
 
 public class Library {}

--- a/junit5-vanilla-java9/src/main/org.example.library/org/example/library/Library.java
+++ b/junit5-vanilla-java9/src/main/org.example.library/org/example/library/Library.java
@@ -1,0 +1,3 @@
+package org.example.library;
+
+public class Library {}

--- a/junit5-vanilla-java9/src/test/com.example.project/com/example/project/CalculatorTests.java
+++ b/junit5-vanilla-java9/src/test/com.example.project/com/example/project/CalculatorTests.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
 package com.example.project;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/junit5-vanilla-java9/src/test/com.example.project/com/example/project/CalculatorTests.java
+++ b/junit5-vanilla-java9/src/test/com.example.project/com/example/project/CalculatorTests.java
@@ -1,0 +1,18 @@
+package com.example.project;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+class CalculatorTests {
+
+  @Test
+  @DisplayName("JUnit 5 test!")
+  void myFirstTest(TestInfo testInfo) {
+    Calculator calculator = new Calculator();
+    assertEquals(2, calculator.add(1, 1), "1 + 1 should equal 2");
+    assertEquals("JUnit 5 test!", testInfo.getDisplayName(), () -> "TestInfo is injected");
+  }
+}

--- a/junit5-vanilla-java9/src/test/com.example.project/com/example/project/api/ProtectedVersionTests.java
+++ b/junit5-vanilla-java9/src/test/com.example.project/com/example/project/api/ProtectedVersionTests.java
@@ -1,0 +1,12 @@
+package com.example.project.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class ProtectedVersionTests {
+  @Test
+  void versionEquals4711() {
+    assertEquals("47.11", ProtectedVersion.VERSION);
+  }
+}

--- a/junit5-vanilla-java9/src/test/com.example.project/com/example/project/api/ProtectedVersionTests.java
+++ b/junit5-vanilla-java9/src/test/com.example.project/com/example/project/api/ProtectedVersionTests.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
 package com.example.project.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/junit5-vanilla-java9/src/test/com.example.project/com/example/project/api/ProtectedVersionTests.java
+++ b/junit5-vanilla-java9/src/test/com.example.project/com/example/project/api/ProtectedVersionTests.java
@@ -18,5 +18,6 @@ class ProtectedVersionTests {
   @Test
   void versionEquals4711() {
     assertEquals("47.11", ProtectedVersion.VERSION);
+    // assertEquals("Project", Project.class.getSimpleName());
   }
 }

--- a/junit5-vanilla-java9/src/test/com.example.project/module-info.java
+++ b/junit5-vanilla-java9/src/test/com.example.project/module-info.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
 open module com.example.project {
   requires org.example.library;
   requires org.junit.jupiter.api;

--- a/junit5-vanilla-java9/src/test/com.example.project/module-info.java
+++ b/junit5-vanilla-java9/src/test/com.example.project/module-info.java
@@ -1,0 +1,4 @@
+open module com.example.project {
+  requires org.example.library;
+  requires org.junit.jupiter.api;
+}

--- a/junit5-vanilla-java9/src/user/integration/integration/IntegrationTests.java
+++ b/junit5-vanilla-java9/src/user/integration/integration/IntegrationTests.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
 package integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/junit5-vanilla-java9/src/user/integration/integration/IntegrationTests.java
+++ b/junit5-vanilla-java9/src/user/integration/integration/IntegrationTests.java
@@ -1,0 +1,37 @@
+package integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.example.project.api.Project;
+import org.example.library.Library;
+import org.junit.jupiter.api.Test;
+
+class IntegrationTests {
+
+  @Test
+  void explicitModuleNames() {
+    assertEquals("com.example.project", Project.class.getModule().getName());
+    assertEquals("org.example.library", Library.class.getModule().getName());
+  }
+
+  @Test
+  void projectIsAccessable() {
+    Project project = new Project();
+    assertEquals("47.11", project.getVersion());
+  }
+
+  @Test
+  void libraryIsAccessable() {
+    Library library = new Library();
+    assertEquals("Library", library.getClass().getSimpleName());
+  }
+
+  // The following does not even compile!
+  // error: package com.example.project is not visible
+  // package com.example.project is declared in module com.example.project, which does not export it
+  //  @Test
+  //  void calculatorIsAccessable() {
+  //    com.example.project.Calculator calculator = new com.example.project.Calculator();
+  //    assertEquals(2, calculator.add(1, 1), "1 + 1 should equal 2");
+  //  }
+}

--- a/junit5-vanilla-java9/src/user/integration/module-info.java
+++ b/junit5-vanilla-java9/src/user/integration/module-info.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
 open module integration {
   requires org.example.library;
   requires com.example.project;

--- a/junit5-vanilla-java9/src/user/integration/module-info.java
+++ b/junit5-vanilla-java9/src/user/integration/module-info.java
@@ -1,0 +1,5 @@
+open module integration {
+  requires org.example.library;
+  requires com.example.project;
+  requires org.junit.jupiter.api;
+}


### PR DESCRIPTION
## Overview

This PR adds a "junit5-vanilla-java9" sample -- loosely based upon techniques described at http://openjdk.java.net/projects/jigsaw/quick-start

### Build tool

There's no external build tool involved. The pojo `Build.java` stored in `src/build` and callable by the JShell script `build.jsh` compiles and launches the test runs in a platform-independent manner. Either start the sample via `jshell build.jsh` or mount the `src/build` as a source directory within your IDE and "press play on tape" (i.e. run main method of class `Build`).

### Directory layout

**`src/main`**
Contains the sources of a sample library and an application that uses the library.

**`src/test`**
Contains the sources for testing the library and application -- legacy style. Strong module boundaries are lifted by patching in main sources.

**`src/user`**
Contains the sources for testing the library and application -- from an end-user point-of-view. The tests are only able to see and use the exported parts of the main modules.

## Build log

Build 43 - https://travis-ci.org/junit-team/junit5-samples/builds/277217191
Build 46 - https://travis-ci.org/junit-team/junit5-samples/jobs/277446838
Build 89 - https://travis-ci.org/junit-team/junit5-samples/jobs/282015679

## TODO

- [x] Include sample in Travis CI script (switch to JDK9)
- [x] Add README.md to `junit5-vanilla-java9` directory
- [ ] Cleanup tests: show more a) deep-reflection examples and b) user integration tests
---
I hereby agree to the terms of the JUnit Contributor License Agreement.
