### PR TITLE
Down to a single dependency

### DIFF
--- a/junit5-vanilla-maven/pom.xml
+++ b/junit5-vanilla-maven/pom.xml
@@ -17,12 +17,6 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-api</artifactId>
-			<version>${junit.jupiter.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
 			<version>${junit.jupiter.version}</version>
 			<scope>test</scope>


### PR DESCRIPTION
## Overview

Trying to reduce the Vanilla Maven dependency to a single entry: only `junit-jupiter-engine`

Addresses #34 

---
I hereby agree to the terms of the JUnit Contributor License Agreement.
