### PR TITLE
Build samples using JUnit 5 SNAPSHOT artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,12 @@ jobs:
       script: cd $TRAVIS_BUILD_DIR/junit5-mockito-extension && ./gradlew test --console plain
     - stage: junit5-vanilla-gradle
       script: cd $TRAVIS_BUILD_DIR/junit5-vanilla-gradle && ./gradlew test --console plain
+    - stage: junit5-vanilla-gradle-SNAPSHOT
+      script: cd $TRAVIS_BUILD_DIR/junit5-vanilla-gradle && ./gradlew test --console plain --build-file build-SNAPSHOT.gradle
     - stage: junit5-vanilla-maven
       script: cd $TRAVIS_BUILD_DIR/junit5-vanilla-maven && ./mvnw test
+    - stage: junit5-vanilla-maven-SNAPSHOT
+      script: cd $TRAVIS_BUILD_DIR/junit5-vanilla-maven && ./mvnw test --file pom-SNAPSHOT.xml
     - stage: junit5-java9-engine
       jdk: oraclejdk9
       script: cd $TRAVIS_BUILD_DIR/junit5-java9-engine && ./gradlew test --console plain

--- a/junit5-vanilla-gradle/build-SNAPSHOT.gradle
+++ b/junit5-vanilla-gradle/build-SNAPSHOT.gradle
@@ -1,0 +1,24 @@
+buildscript {
+	repositories {
+		mavenCentral()
+		maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+	}
+	dependencies {
+		classpath 'org.junit.platform:junit-platform-gradle-plugin:1.1.0-SNAPSHOT'
+	}
+}
+
+apply plugin: 'java'
+apply plugin: 'org.junit.platform.gradle.plugin'
+
+repositories {
+	mavenCentral()
+	maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+}
+
+dependencies {
+	testCompile('org.junit.jupiter:junit-jupiter-api:5.1.0-SNAPSHOT')
+	testRuntime('org.junit.jupiter:junit-jupiter-engine:5.1.0-SNAPSHOT')
+	// To avoid compiler warnings about @API annotations in JUnit code
+	testCompileOnly('org.apiguardian:apiguardian-api:1.1.0-SNAPSHOT')
+}

--- a/junit5-vanilla-maven/pom-SNAPSHOT.xml
+++ b/junit5-vanilla-maven/pom-SNAPSHOT.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.example</groupId>
+	<artifactId>junit5-vanilla-maven-snapshot</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<java.version>1.8</java.version>
+		<junit.jupiter.version>5.1.0-SNAPSHOT</junit.jupiter.version>
+		<junit.platform.version>1.1.0-SNAPSHOT</junit.platform.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>${junit.jupiter.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<!-- To avoid compiler warnings about @API annotations in JUnit code -->
+		<dependency>
+			<groupId>org.apiguardian</groupId>
+			<artifactId>apiguardian-api</artifactId>
+			<version>1.1.0-SNAPSHOT</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<repositories>
+		<repository>
+			<id>oss-sonatype</id>
+			<name>oss-sonatype</name>
+			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>oss-sonatype</id>
+			<name>oss-sonatype</name>
+			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.7.0</version>
+				<configuration>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.19.1</version>
+				<configuration>
+					<includes>
+						<include>**/Test*.java</include>
+						<include>**/*Test.java</include>
+						<include>**/*Tests.java</include>
+						<include>**/*TestCase.java</include>
+					</includes>
+				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>org.junit.platform</groupId>
+						<artifactId>junit-platform-surefire-provider</artifactId>
+						<version>${junit.platform.version}</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>


### PR DESCRIPTION
## Overview

Building samples using JUnit 5 SNAPSHOT artifacts ensures we don't break basic functionality. 

## TODO
- [ ] Add `build-SNAPSHOT.gradle` to all Gradle-based samples
- [ ] Add `pom-SNAPSHOT.xml` to all Maven-based samples
- [ ] Beautify Travis CI build script using matrix/stage combination

---
I hereby agree to the terms of the JUnit Contributor License Agreement.
