### PR TITLE
Allow subprojects to be published using JitPack

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+install:
+  - ./junit5-gradle-consumer/gradlew -b ./junit5-gradle-consumer/build.gradle install -Pgroup=$GROUP -Pversion=$VERSION --console plain
+  - ./junit5-mockito-extension/gradlew -b ./junit5-mockito-extension/build.gradle install -Pgroup=$GROUP -Pversion=$VERSION --console plain

--- a/junit5-gradle-consumer/build.gradle
+++ b/junit5-gradle-consumer/build.gradle
@@ -20,6 +20,7 @@ ext.log4jVersion         = '2.9.0'
 apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
+apply plugin: 'maven'
 apply plugin: 'org.junit.platform.gradle.plugin'
 
 jar {


### PR DESCRIPTION
## Overview

Per a discussion in #38.

This PR (in conjunction with 3991514) allows the artifacts from the junit5-gradle-consumer and junit5-mockito-extension subprojects to be consumed via JitPack.

## Details

In order for JitPack to publish the subprojects at the expected coordinates, at least two subprojects must be published.  Otherwise, the single subproject is published at the coordinates for the repo as a whole.  The JitPack coordinates for multi-module build artifacts are described [here](https://jitpack.io/docs/BUILDING/#multi-module-projects).

Because this repo contains both Gradle and Maven subprojects, a custom JitPack build script is used to build the individual subprojects.  This differs from the canonical JitPack multi-module build examples (see [here](https://github.com/jitpack/gradle-modular) and [here](https://github.com/jitpack/maven-modular)), which use a single build tool per repo, and thus can use the build tool's multi-module project support.

Additional subprojects can be published by adding the appropriate build command to _jitpack.yml_.

---
I hereby agree to the terms of the JUnit Contributor License Agreement.