### PR TITLE
Use built-in JUnit platform support in Gradle 4.6

### DIFF
--- a/junit5-gradle-consumer/build.gradle
+++ b/junit5-gradle-consumer/build.gradle
@@ -1,12 +1,3 @@
-buildscript {
-	repositories {
-		mavenCentral()
-	}
-	dependencies {
-		classpath 'org.junit.platform:junit-platform-gradle-plugin:1.1.0'
-	}
-}
-
 repositories {
 	mavenCentral()
 }
@@ -21,7 +12,6 @@ apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
 apply plugin: 'maven'
-apply plugin: 'org.junit.platform.gradle.plugin'
 
 jar {
 	baseName = 'junit5-gradle-consumer'
@@ -34,23 +24,22 @@ compileTestJava {
 	options.compilerArgs += '-parameters'
 }
 
-junitPlatform {
-	// platformVersion '1.1.0'
-	filters {
-		engines {
-			// include 'junit-jupiter', 'junit-vintage'
-			// exclude 'custom-engine'
-		}
-		tags {
-			// include 'fast'
-			exclude 'slow'
-		}
-		// includeClassNamePattern '.*Test'
+test {
+	useJUnitPlatform {
+		// includeEngines 'junit-jupiter', 'junit-vintage'
+		// excludeEngines 'custom-engine'
+
+		// includeTags 'fast'
+		excludeTags 'slow'
 	}
-	// configurationParameter 'junit.jupiter.conditions.deactivate', '*'
-	// enableStandardTestTask true
-	// reportsDir file('build/test-results/junit-platform') // this is the default
-	logManager 'org.apache.logging.log4j.jul.LogManager'
+
+	testLogging {
+		events 'passed', 'skipped', 'failed'
+	}
+
+	reports {
+		html.enabled = true
+	}
 }
 
 dependencies {
@@ -72,5 +61,5 @@ dependencies {
 
 task wrapper(type: Wrapper) {
 	description = 'Generates gradlew[.bat] scripts'
-	gradleVersion = '4.3.1'
+	gradleVersion = '4.6'
 }

--- a/junit5-gradle-consumer/build.gradle
+++ b/junit5-gradle-consumer/build.gradle
@@ -47,16 +47,14 @@ dependencies {
 	testCompile("org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}")
 	testRuntime("org.junit.jupiter:junit-jupiter-engine:${junitJupiterVersion}")
 
-	// If you also want to support JUnit 3 and JUnit 4 tests
 	testCompile("junit:junit:${junit4Version}")
-	testRuntime("org.junit.vintage:junit-vintage-engine:${junitVintageVersion}")
+	testRuntime("org.junit.vintage:junit-vintage-engine:${junitVintageVersion}") {
+		because 'allows JUnit 3 and JUnit 4 tests to run'
+	}
 
-	// To use Log4J's LogManager
-	testRuntime("org.apache.logging.log4j:log4j-core:${log4jVersion}")
-	testRuntime("org.apache.logging.log4j:log4j-jul:${log4jVersion}")
-
-	// Only needed to run tests in an (IntelliJ) IDE(A) that bundles an older version
-	testRuntime("org.junit.platform:junit-platform-launcher:${junitPlatformVersion}")
+	testRuntime("org.junit.platform:junit-platform-launcher:${junitPlatformVersion}") {
+		because 'allows tests to run from IDEs that bundle older version of launcher'
+	}
 }
 
 task wrapper(type: Wrapper) {

--- a/junit5-gradle-consumer/gradle/wrapper/gradle-wrapper.properties
+++ b/junit5-gradle-consumer/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip


### PR DESCRIPTION
## Overview

This eliminates the need for the junit-gradle-plugin, replacing it instead with configuring the JUnit platform through the `Test` task.

Dependencies declarations are also optimized a little bit.

See https://docs.gradle.org/4.6/userguide/java_plugin.html#using_junit5 and https://docs.gradle.org/4.6/userguide/managing_transitive_dependencies.html

### Testing Done

Ran `./gradlew test` and executed tests from IntelliJ 2017.3

---

 - [x] I hereby agree to the terms of the JUnit Contributor License Agreement.
