### PR TITLE
[WIP] Upgrade to maven-surefire-plugin 2.22.0

### DIFF
--- a/junit5-jupiter-starter-maven/pom-SNAPSHOT.xml
+++ b/junit5-jupiter-starter-maven/pom-SNAPSHOT.xml
@@ -55,6 +55,11 @@
                 <enabled>true</enabled>
             </snapshots>
         </pluginRepository>
+        <!-- only needed until "maven-surefire-plugin" 2.22.0 is published... -->
+        <pluginRepository>
+            <id>staged-releases</id>
+            <url>https://repository.apache.org/content/repositories/maven-1436</url>
+        </pluginRepository>
     </pluginRepositories>
 
     <build>
@@ -69,14 +74,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.21.0</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.junit.platform</groupId>
-                        <artifactId>junit-platform-surefire-provider</artifactId>
-                        <version>${junit.platform.version}</version>
-                    </dependency>
-                </dependencies>
+                <version>2.22.0</version>
             </plugin>
         </plugins>
     </build>

--- a/junit5-jupiter-starter-maven/pom.xml
+++ b/junit5-jupiter-starter-maven/pom.xml
@@ -35,6 +35,14 @@
 		</dependency>
 	</dependencies>
 
+	<!-- only needed until "maven-surefire-plugin" 2.22.0 is published... -->
+	<pluginRepositories>
+		<pluginRepository>
+			<id>staged-releases</id>
+			<url>https://repository.apache.org/content/repositories/maven-1436</url>
+		</pluginRepository>
+	</pluginRepositories>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -47,14 +55,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.21.0</version>
-				<dependencies>
-					<dependency>
-						<groupId>org.junit.platform</groupId>
-						<artifactId>junit-platform-surefire-provider</artifactId>
-						<version>${junit.platform.version}</version>
-					</dependency>
-				</dependencies>
+				<version>2.22.0</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/junit5-migration-maven/pom.xml
+++ b/junit5-migration-maven/pom.xml
@@ -17,6 +17,14 @@
 		<junit.platform.version>1.2.0</junit.platform.version>
 	</properties>
 
+	<!-- only needed until "maven-surefire-plugin" 2.22.0 is published... -->
+	<pluginRepositories>
+		<pluginRepository>
+			<id>staged-releases</id>
+			<url>https://repository.apache.org/content/repositories/maven-1436</url>
+		</pluginRepository>
+	</pluginRepositories>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -29,11 +37,11 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.21.0</version>
+				<version>2.22.0</version>
 				<configuration>
+					<!--<groups>fast</groups>-->
+					<excludedGroups>slow</excludedGroups>
 					<properties>
-						<!-- <includeTags>fast</includeTags> -->
-						<excludeTags>slow</excludeTags>
 						<!--
 						<configurationParameters>
 							junit.jupiter.conditions.deactivate = *
@@ -41,13 +49,6 @@
 						-->
 					</properties>
 				</configuration>
-				<dependencies>
-					<dependency>
-						<groupId>org.junit.platform</groupId>
-						<artifactId>junit-platform-surefire-provider</artifactId>
-						<version>${junit.platform.version}</version>
-					</dependency>
-				</dependencies>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
## Overview

After https://issues.apache.org/jira/browse/SUREFIRE-1330 being merged and the _soon-to-be-published_ `maven-surefire-plugin` version 2.22.0 contains a JUnit Platform Surefire Provider by default. No need to include the `junit-platform-surefire-provider` any longer.

---
I hereby agree to the terms of the JUnit Contributor License Agreement.
