### PR TITLE
Clarify plugin requirements

### DIFF
--- a/junit5-jupiter-starter-maven/pom.xml
+++ b/junit5-jupiter-starter-maven/pom.xml
@@ -45,6 +45,8 @@
 					<target>${java.version}</target>
 				</configuration>
 			</plugin>
+
+			<!-- Junit 5 requires Surefire version 2.22.0 or higher -->
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.22.0</version>

--- a/junit5-jupiter-starter-maven/pom.xml
+++ b/junit5-jupiter-starter-maven/pom.xml
@@ -9,7 +9,9 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<java.version>1.8</java.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
+
 		<junit.jupiter.version>5.2.0</junit.jupiter.version>
 		<junit.platform.version>1.2.0</junit.platform.version>
 	</properties>
@@ -37,15 +39,6 @@
 
 	<build>
 		<plugins>
-			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.7.0</version>
-				<configuration>
-					<source>${java.version}</source>
-					<target>${java.version}</target>
-				</configuration>
-			</plugin>
-
 			<!-- Junit 5 requires Surefire version 2.22.0 or higher -->
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>

--- a/junit5-migration-maven/pom.xml
+++ b/junit5-migration-maven/pom.xml
@@ -10,7 +10,9 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<java.version>1.8</java.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
+
 		<junit.version>4.12</junit.version>
 		<junit.jupiter.version>5.2.0</junit.jupiter.version>
 		<junit.vintage.version>5.2.0</junit.vintage.version>
@@ -19,15 +21,6 @@
 
 	<build>
 		<plugins>
-			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.7.0</version>
-				<configuration>
-					<source>${java.version}</source>
-					<target>${java.version}</target>
-				</configuration>
-			</plugin>
-
 			<!-- Junit 5 requires Surefire version 2.22.0 or higher -->
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>

--- a/junit5-migration-maven/pom.xml
+++ b/junit5-migration-maven/pom.xml
@@ -27,6 +27,8 @@
 					<target>${java.version}</target>
 				</configuration>
 			</plugin>
+
+			<!-- Junit 5 requires Surefire version 2.22.0 or higher -->
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.22.0</version>


### PR DESCRIPTION
- Comment pointing out requirement for Surefire version 2.22.0
- Version of Maven compiler plugin is irrelevant. Only Java version has to be at least 1.8

---
I hereby agree to the terms of the JUnit Contributor License Agreement.
