### PR TITLE
Remove transitive dependencies in Maven projects

### DIFF
--- a/junit5-jupiter-starter-maven/pom.xml
+++ b/junit5-jupiter-starter-maven/pom.xml
@@ -19,12 +19,6 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-api</artifactId>
-			<version>${junit.jupiter.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-params</artifactId>
 			<version>${junit.jupiter.version}</version>
 			<scope>test</scope>

--- a/junit5-migration-maven/pom.xml
+++ b/junit5-migration-maven/pom.xml
@@ -6,7 +6,6 @@
 	<groupId>com.example</groupId>
 	<artifactId>junit5-migration-maven</artifactId>
 	<version>1.0-SNAPSHOT</version>
-	<packaging>jar</packaging>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/junit5-migration-maven/pom.xml
+++ b/junit5-migration-maven/pom.xml
@@ -12,7 +12,6 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
 
-		<junit.version>4.12</junit.version>
 		<junit.jupiter.version>5.2.0</junit.jupiter.version>
 		<junit.vintage.version>5.2.0</junit.vintage.version>
 		<junit.platform.version>1.2.0</junit.platform.version>
@@ -40,18 +39,6 @@
 	</build>
 
 	<dependencies>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-api</artifactId>
-			<version>${junit.jupiter.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>${junit.version}</version>
-			<scope>test</scope>
-		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>


### PR DESCRIPTION
Reasons I'm suggesting this:

1. No need to declare them explicitly.
junit-jupiter-api and junit are already included as transitive dependencies of junit-jupiter-engine and junit-vintage-engine.
2. It simplifies including JUnit 5.
JUnit is the most popular Maven dependency. It is important to make the inclusion of JUnit 5 as simple as possible. In my opinion, this is more important than being explicit about separation of API and implementation.

---
I hereby agree to the terms of the JUnit Contributor License Agreement.
