### PR TITLE
Remove unused property junit.platform.version

### DIFF
--- a/junit5-jupiter-starter-maven/pom.xml
+++ b/junit5-jupiter-starter-maven/pom.xml
@@ -13,7 +13,6 @@
 		<maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
 
 		<junit.jupiter.version>5.3.0</junit.jupiter.version>
-		<junit.platform.version>1.3.0</junit.platform.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
## Overview

Property is not used and can be dropped.

---
I hereby agree to the terms of the JUnit Contributor License Agreement.
