### PR TITLE
remove unused property

### DIFF
--- a/junit5-migration-maven/pom.xml
+++ b/junit5-migration-maven/pom.xml
@@ -16,7 +16,6 @@
 		<junit.version>4.12</junit.version>
 		<junit.jupiter.version>5.3.2</junit.jupiter.version>
 		<junit.vintage.version>5.3.2</junit.vintage.version>
-		<junit.platform.version>1.3.2</junit.platform.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
## Overview

remove unused property in junit migration project.
-

when I am reading the pom.xml to study Junit5 dependency, I did detect the property to unused.
if this property is used somewhere, I will close this PR. :) 

---
I hereby agree to the terms of the JUnit Contributor License Agreement.
