### PR TITLE
Adding assertThrows example to junit5-jupiter-starter-gradle-kotlin

### DIFF
--- a/junit5-jupiter-starter-gradle-kotlin/build.gradle.kts
+++ b/junit5-jupiter-starter-gradle-kotlin/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-	kotlin("jvm") version "1.2.41"
+	kotlin("jvm") version "1.3.20"
 }
 
 repositories {

--- a/junit5-jupiter-starter-gradle-kotlin/build.gradle.kts
+++ b/junit5-jupiter-starter-gradle-kotlin/build.gradle.kts
@@ -7,6 +7,8 @@ repositories {
 }
 
 dependencies {
+	implementation(kotlin("stdlib-jdk8"))
+	// or compile("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 	testCompile("org.junit.jupiter:junit-jupiter-api:5.3.2")
 	testCompile("org.junit.jupiter:junit-jupiter-params:5.3.2")
 	testRuntime("org.junit.jupiter:junit-jupiter-engine:5.3.2")

--- a/junit5-jupiter-starter-gradle-kotlin/build.gradle.kts
+++ b/junit5-jupiter-starter-gradle-kotlin/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
 	kotlin("jvm") version "1.3.20"
 }
@@ -23,4 +25,9 @@ tasks.withType<Test> {
 
 tasks.withType<Wrapper> {
 	gradleVersion = "5.0"
+}
+
+// config JVM target to 1.8 for kotlin compilation tasks
+tasks.withType<KotlinCompile> {
+	kotlinOptions.jvmTarget = "1.8"
 }

--- a/junit5-jupiter-starter-gradle-kotlin/src/main/kotlin/com/example/project/Calculator.kt
+++ b/junit5-jupiter-starter-gradle-kotlin/src/main/kotlin/com/example/project/Calculator.kt
@@ -16,4 +16,9 @@ class Calculator {
         return a + b
     }
 
+    fun div(a: Int, b: Int): Double {
+        assert(b != 0) { "Division by Zero" }
+        return a / b * 1.0
+    }
+
 }

--- a/junit5-jupiter-starter-gradle-kotlin/src/test/kotlin/com/example/project/CalculatorTests.kt
+++ b/junit5-jupiter-starter-gradle-kotlin/src/test/kotlin/com/example/project/CalculatorTests.kt
@@ -13,6 +13,7 @@ package com.example.project
 import org.junit.jupiter.api.Assertions.assertEquals
 
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
@@ -36,5 +37,14 @@ class CalculatorTests {
         assertEquals(expectedResult, calculator.add(first, second)) {
             "$first + $second should equal $expectedResult"
         }
+    }
+
+    @Test
+    fun divisionByZeroError() {
+        val calculator = Calculator()
+        val exception = assertThrows<AssertionError> {
+            calculator.div(1, 0)
+        }
+        assertEquals("Division by Zero", exception.message)
     }
 }


### PR DESCRIPTION
## Overview

- Update Koltin version to 1.3.20
- Add `kotlin-stdlib-jdk8` dependency
- Add `div(int, int)` function to Calculator and `divisionByZero()` to show case `assertThrows` usage

---
I hereby agree to the terms of the JUnit Contributor License Agreement.
