### PR TITLE
change java_junit5_test rule to run all tests in package level instead of class level

### DIFF
--- a/junit5-jupiter-starter-bazel/junit5.bzl
+++ b/junit5-jupiter-starter-bazel/junit5.bzl
@@ -53,7 +53,7 @@ def junit_platform_java_repositories(
             ),
         )
 
-def java_junit5_test(name, srcs, test_package = None, deps = [], runtime_deps = [], **kwargs):
+def java_junit5_test(name, srcs, test_package, deps = [], runtime_deps = [], **kwargs):
     FILTER_KWARGS = [
         "main_class",
         "use_testrunner",

--- a/junit5-jupiter-starter-bazel/junit5.bzl
+++ b/junit5-jupiter-starter-bazel/junit5.bzl
@@ -53,7 +53,7 @@ def junit_platform_java_repositories(
             ),
         )
 
-def java_junit5_test(name, srcs, test_class = None, deps = [], runtime_deps = [], **kwargs):
+def java_junit5_test(name, srcs, test_package = None, deps = [], runtime_deps = [], **kwargs):
     FILTER_KWARGS = [
         "main_class",
         "use_testrunner",
@@ -65,10 +65,10 @@ def java_junit5_test(name, srcs, test_class = None, deps = [], runtime_deps = []
             kwargs.pop(arg)
 
     junit_console_args = []
-    if test_class:
-        junit_console_args += ["--select-class", test_class]
+    if test_package:
+        junit_console_args += ["--select-package", test_package]
     else:
-        fail("must specific 'test_class'")
+        fail("must specify 'test_package'")
 
     native.java_test(
         name = name,

--- a/junit5-jupiter-starter-bazel/src/test/java/com/example/project/BUILD
+++ b/junit5-jupiter-starter-bazel/src/test/java/com/example/project/BUILD
@@ -10,7 +10,7 @@ java_junit5_test(
     srcs = glob([
         "CalculatorTests.java",
     ]),
-    test_class = "com.example.project.CalculatorTests",
+    test_package = "com.example.project",
     deps = [
         "//src/main/java/com/example/project:junit5-jupiter-starter-bazel",
     ],


### PR DESCRIPTION
## Overview

change java_junit5_test rule to run all tests in package level instead of class level.
This will allow to write and maintain less bazel targets

---
I hereby agree to the terms of the JUnit Contributor License Agreement.
