### PR TITLE
Remove 'java' from junit5-jupiter-starter-maven-kotlin #104 PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,10 @@ Groovy programming language.
 The [junit5-jupiter-starter-maven] sample demonstrates the bare minimum configuration for
 getting started with JUnit Jupiter using the Maven build system.
 
-### Jupiter on Maven using Kotlin ![badge-jdk-8] ![badge-tool-maven] ![badge-junit-jupiter] ![badge-junit-vintage]
+### Jupiter on Maven using Kotlin ![badge-jdk-8] ![badge-tool-maven] ![badge-junit-jupiter]
 
 The [junit5-jupiter-starter-maven-kotlin] sample demonstrates the bare minimum configuration for
-getting started with JUnit Jupiter and JUnit Vintage project using Maven build system and Kotlin
-programming language.
+getting started with JUnit Jupiter project using Maven build system and Kotlin programming language.
 
 ### Jupiter on Bazel ![badge-jdk-8] ![badge-tool-bazel] ![badge-junit-jupiter]
 

--- a/junit5-jupiter-starter-maven-kotlin/README.md
+++ b/junit5-jupiter-starter-maven-kotlin/README.md
@@ -1,7 +1,7 @@
 # junit5-jupiter-starter-maven-kotlin [![Build Status](https://travis-ci.org/junit-team/junit5-samples.svg?branch=master)](https://travis-ci.org/junit-team/junit5-samples)
 
-The `junit5-jupiter-starter-maven-kotlin` sample demonstrates how to execute JUnit 4 Vintage test together
-with JUnit 5 Jupiter tests by using Maven build tool in mixed java / kotlin test classes in the project:
+The `junit5-jupiter-starter-maven-kotlin` sample demonstrates the bare minimum configuration for
+getting started with JUnit Jupiter project using Maven build system and Kotlin programming language.
 
 Please note that this project is uses the [Maven Wrapper](https://github.com/takari/maven-wrapper)
 3.6.1 version. This helps you ensure that already tested versions are not going to be failed if

--- a/junit5-jupiter-starter-maven-kotlin/pom.xml
+++ b/junit5-jupiter-starter-maven-kotlin/pom.xml
@@ -22,14 +22,12 @@
 	</properties>
 
 	<dependencies>
-		<!-- Kotlin related dependencies -->
 		<dependency>
 			<groupId>org.jetbrains.kotlin</groupId>
 			<artifactId>kotlin-stdlib</artifactId>
 			<version>${kotlin.version}</version>
 		</dependency>
 
-		<!-- JUnit Jupiter + Kotlin Test JUnit 5 Asserter -->
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
@@ -42,24 +40,11 @@
 			<version>${kotlin.version}</version>
 			<scope>test</scope>
 		</dependency>
-
-		<!-- JUnit Vintage + Kotlin Test JUnit 4 Asserter -->
-		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
-			<version>${junit.vintage.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.jetbrains.kotlin</groupId>
-			<artifactId>kotlin-test-junit</artifactId>
-			<version>${kotlin.version}</version>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 
 	<build>
-		<defaultGoal>test</defaultGoal>
+		<sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+		<testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
 
 		<plugins>
 			<plugin>
@@ -73,55 +58,12 @@
 						<goals>
 							<goal>compile</goal>
 						</goals>
-						<configuration>
-							<sourceDirs><!-- required when both java and kotlin are mixing together -->
-								<sourceDir>${project.basedir}/src/main/java</sourceDir>
-								<sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
-							</sourceDirs>
-						</configuration>
 					</execution>
 					<execution>
 						<id>test-compile</id>
 						<phase>test-compile</phase>
 						<goals>
 							<goal>test-compile</goal>
-						</goals>
-						<configuration>
-							<sourceDirs><!-- required when both java and kotlin are mixing together -->
-								<sourceDir>${project.basedir}/src/test/java</sourceDir>
-								<sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
-							</sourceDirs>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-
-			<!-- required when both java and kotlin are mixing together -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>${maven.compiler.plugin.version}</version>
-				<executions>
-					<execution>
-						<id>default-compile</id>
-						<phase>none</phase>
-					</execution>
-					<execution>
-						<id>default-testCompile</id>
-						<phase>none</phase>
-					</execution>
-					<execution>
-						<id>java-compile</id>
-						<phase>compile</phase>
-						<goals>
-							<goal>compile</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>java-test-compile</id>
-						<phase>test-compile</phase>
-						<goals>
-							<goal>testCompile</goal>
 						</goals>
 					</execution>
 				</executions>

--- a/junit5-jupiter-starter-maven-kotlin/src/main/kotlin/com/example/project/Calculator.kt
+++ b/junit5-jupiter-starter-maven-kotlin/src/main/kotlin/com/example/project/Calculator.kt
@@ -8,12 +8,8 @@
  * http://www.eclipse.org/legal/epl-v20.html
  */
 
-package com.example.project;
+package com.example.project
 
-public class Calculator {
-
-	public int add(int a, int b) {
-		return a + b;
-	}
-
+class Calculator {
+	fun add(a: Int, b: Int) = a + b
 }

--- a/junit5-jupiter-starter-maven-kotlin/src/test/kotlin/com/example/project/CalculatorTests.kt
+++ b/junit5-jupiter-starter-maven-kotlin/src/test/kotlin/com/example/project/CalculatorTests.kt
@@ -18,23 +18,20 @@ import org.junit.jupiter.params.provider.CsvSource
 
 internal class CalculatorTests {
 
-  @Test
-  internal fun `1 + 1 = 2`() {
-    val calculator = Calculator()
-    assertEquals(2, calculator.add(1, 1), "1 + 1 should equal 2")
-  }
+	@Test
+	internal fun `1 + 1 = 2`() = assertEquals(2, Calculator().add(1, 1), "1 + 1 should equal 2")
 
-  @ParameterizedTest(name = "{0} + {1} = {2}")
-  @CsvSource(
-      "0 ,   1,   1",
-      "1 ,   2,   3",
-      "49,  51, 100",
-      "1 , 100, 101"
-  )
-  internal fun add(first: Int, second: Int, expectedResult: Int) {
-    val calculator = Calculator()
-    assertEquals(expectedResult, calculator.add(first, second)) {
-      "$first + $second should equal $expectedResult"
-    }
-  }
+	@ParameterizedTest(name = "{0} + {1} = {2}")
+	@CsvSource(
+			"0 ,   1,   1",
+			"1 ,   2,   3",
+			"49,  51, 100",
+			"1 , 100, 101"
+	)
+	internal fun add(first: Int, second: Int, expectedResult: Int) {
+		val calculator = Calculator()
+		assertEquals(expectedResult, calculator.add(first, second)) {
+			"$first + $second should equal $expectedResult"
+		}
+	}
 }


### PR DESCRIPTION
## Overview

This PR contains #104 issue fixes:

- Remove java from junit5-jupiter-starter-maven-kotlin sample project.
- Trim pom.xml down to the minimum of configurations needed to get Maven + Kotlin + Jupiter happy.

---
I hereby agree to the terms of the JUnit Contributor License Agreement.
