### PR TITLE
Switch to JDK 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jobs:
 # starter
     - stage: starter
       name: "Jupiter Starter Sample: Ant"
-      before_script: jdk_switcher use oraclejdk8
+      before_script: jdk_switcher use openjdk8
       script: cd $TRAVIS_BUILD_DIR/junit5-jupiter-starter-ant && ./build.sh
     - stage: starter
       name: "Jupiter Starter Sample: Gradle & Java"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: java
-# jdk: oraclejdk8 # use default JDK
+jdk: openjdk8
 
 jobs:
   include:
 # starter
     - stage: starter
       name: "Jupiter Starter Sample: Ant"
-      before_script: jdk_switcher use openjdk8
       script: cd $TRAVIS_BUILD_DIR/junit5-jupiter-starter-ant && ./build.sh
     - stage: starter
       name: "Jupiter Starter Sample: Gradle & Java"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ jobs:
 # starter
     - stage: starter
       name: "Jupiter Starter Sample: Ant"
+      before_script: jdk_switcher use oraclejdk8
       script: cd $TRAVIS_BUILD_DIR/junit5-jupiter-starter-ant && ./build.sh
     - stage: starter
       name: "Jupiter Starter Sample: Gradle & Java"


### PR DESCRIPTION
## Overview
Use default JDK per default and only switch some jobs to JDK 8 before executing the script phase.
---
I hereby agree to the terms of the JUnit Contributor License Agreement.
