### PR TITLE
Reproducer for "JUnit3 suite with subsuite failure"

### DIFF
--- a/junit5-migration-gradle/build.gradle
+++ b/junit5-migration-gradle/build.gradle
@@ -45,6 +45,7 @@ test {
 
 	testLogging {
 		events 'passed', 'skipped', 'failed'
+		showStandardStreams = true
 	}
 
 	finalizedBy(jacocoTestReport)

--- a/junit5-migration-gradle/src/test/java/com/example/project/SuiteWithSubsuites.java
+++ b/junit5-migration-gradle/src/test/java/com/example/project/SuiteWithSubsuites.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package com.example.project;
+
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+import org.junit.Assert;
+
+public class SuiteWithSubsuites extends TestCase {
+    private final String arg;
+
+    public SuiteWithSubsuites(String name, String arg) {
+        super(name);
+        this.arg = arg;
+    }
+
+    public void hello() {
+        System.out.println("arg = " + arg);
+        Assert.assertNotNull(arg);
+    }
+
+    public static TestSuite suite() {
+        TestSuite root = new TestSuite("allTests");
+        TestSuite case1 = new TestSuite("Case1");
+        case1.addTest(new SuiteWithSubsuites("hello", "world"));
+        root.addTest(case1);
+        TestSuite case2 = new TestSuite("Case2");
+        case2.addTest(new SuiteWithSubsuites("hello", "WORLD"));
+        root.addTest(case2);
+        return root;
+    }
+}


### PR DESCRIPTION
## Overview

This is a reproducer for Vintage failure when JUnit3 suite contains tests with repeated names in different subsuites.

Test output is as follows.

Note: `SuiteWithSubsuites#hello` is registered twice (in different subsuites), so it must be executed twice.
However the second execution produces Gradle exception since Vintage uses non-unique identifiers.

It looks like Vintage runner does not include `suite path` to the `TestIdentifier`.

```
> Task :test

com.example.project.SuiteWithSubsuites > hello STANDARD_OUT
    arg = world

com.example.project.SuiteWithSubsuites > hello PASSED

com.example.project.SuiteWithSubsuites STANDARD_OUT
    arg = WORLD

com.example.project.SuiteWithSubsuites STANDARD_ERROR
    сен 23, 2019 12:24:47 AM org.junit.platform.launcher.core.TestExecutionListenerRegistry lambda$notifyEach$1
    WARNING: TestExecutionListener [org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestExecutionListener] threw exception for method: executionFinished(TestIdentifier [uniqueId = '[engine:junit-vintage]/[runner:com.example.project.SuiteWithSubsuites]/[dynamic:hello(com.example.project.SuiteWithSubsuites)]', parentId = '[engine:junit-vintage]/[runner:com.example.project.SuiteWithSubsuites]', displayName = 'hello', legacyReportingName = 'hello', source = MethodSource [className = 'com.example.project.SuiteWithSubsuites', methodName = 'hello', methodParameterTypes = ''], tags = [], type = TEST], TestExecutionResult [status = SUCCESSFUL, throwable = null])
    java.lang.AssertionError
        at org.gradle.api.internal.tasks.testing.processors.TestOutputRedirector.setOutputOwner(TestOutputRedirector.java:49)
        at org.gradle.api.internal.tasks.testing.processors.CaptureTestOutputTestResultProcessor.completed(CaptureTestOutputTestResultProcessor.java:80)
        at org.gradle.api.internal.tasks.testing.results.AttachParentTestResultProcessor.completed(AttachParentTestResultProcessor.java:56)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:35)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
        at org.gradle.internal.actor.internal.DefaultActorFactory$BlockingActor.dispatch(DefaultActorFactory.java:122)
        at org.gradle.internal.actor.internal.DefaultActorFactory$BlockingActor.dispatch(DefaultActorFactory.java:97)
        at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:93)
        at com.sun.proxy.$Proxy3.completed(Unknown Source)
        at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestExecutionListener.executionFinished(JUnitPlatformTestExecutionListener.java:110)
        at org.junit.platform.launcher.core.TestExecutionListenerRegistry$CompositeTestExecutionListener.lambda$executionFinished$10(TestExecutionListenerRegistry.java:109)
        at org.junit.platform.launcher.core.TestExecutionListenerRegistry.lambda$notifyEach$1(TestExecutionListenerRegistry.java:67)
        at java.util.ArrayList.forEach(ArrayList.java:1257)
        at org.junit.platform.launcher.core.TestExecutionListenerRegistry.notifyEach(TestExecutionListenerRegistry.java:65)
        at org.junit.platform.launcher.core.TestExecutionListenerRegistry.access$200(TestExecutionListenerRegistry.java:32)
        at org.junit.platform.launcher.core.TestExecutionListenerRegistry$CompositeTestExecutionListener.executionFinished(TestExecutionListenerRegistry.java:108)
        at org.junit.platform.launcher.core.ExecutionListenerAdapter.executionFinished(ExecutionListenerAdapter.java:56)
        at org.junit.vintage.engine.execution.RunListenerAdapter.fireExecutionFinished(RunListenerAdapter.java:211)
        at org.junit.vintage.engine.execution.RunListenerAdapter.testFinished(RunListenerAdapter.java:177)
        at org.junit.vintage.engine.execution.RunListenerAdapter.testFinished(RunListenerAdapter.java:76)
        at org.junit.runner.notification.SynchronizedRunListener.testFinished(SynchronizedRunListener.java:56)
        at org.junit.runner.notification.RunNotifier$7.notifyListener(RunNotifier.java:190)
        at org.junit.runner.notification.RunNotifier$SafeNotifier.run(RunNotifier.java:72)
        at org.junit.runner.notification.RunNotifier.fireTestFinished(RunNotifier.java:187)
        at org.junit.internal.runners.JUnit38ClassRunner$OldTestClassAdaptingListener.endTest(JUnit38ClassRunner.java:33)
        at junit.framework.TestResult.endTest(TestResult.java:82)
        at junit.framework.TestResult.run(TestResult.java:127)
        at junit.framework.TestCase.run(TestCase.java:129)
        at junit.framework.TestSuite.runTest(TestSuite.java:252)
        at junit.framework.TestSuite.run(TestSuite.java:247)
        at junit.framework.TestSuite.runTest(TestSuite.java:252)
        at junit.framework.TestSuite.run(TestSuite.java:247)
        at org.junit.internal.runners.JUnit38ClassRunner.run(JUnit38ClassRunner.java:86)
        at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
        at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
        at org.junit.vintage.engine.execution.RunnerExecutor.execute(RunnerExecutor.java:40)
        at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184)
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
        at java.util.Iterator.forEachRemaining(Iterator.java:116)
        at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
        at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
        at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:418)
        at org.junit.vintage.engine.VintageTestEngine.executeAllChildren(VintageTestEngine.java:80)
        at org.junit.vintage.engine.VintageTestEngine.execute(VintageTestEngine.java:71)
        at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:229)
        at org.junit.platform.launcher.core.DefaultLauncher.lambda$execute$6(DefaultLauncher.java:197)
        at org.junit.platform.launcher.core.DefaultLauncher.withInterceptedStreams(DefaultLauncher.java:211)
        at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:191)
        at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:128)
        at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.processAllTestClasses(JUnitPlatformTestClassProcessor.java:102)
        at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.access$000(JUnitPlatformTestClassProcessor.java:82)
        at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor.stop(JUnitPlatformTestClassProcessor.java:78)
        at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.stop(SuiteTestClassProcessor.java:61)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:35)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
        at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:32)
        at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:93)
        at com.sun.proxy.$Proxy2.stop(Unknown Source)
        at org.gradle.api.internal.tasks.testing.worker.TestWorker.stop(TestWorker.java:132)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:35)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
        at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:175)
        at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:157)
        at org.gradle.internal.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:404)
        at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:63)
        at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:46)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:55)
        at java.lang.Thread.run(Thread.java:748)


com.example.project.JUnit4Test > test PASSED

com.example.project.OtherTests > testThisThing() PASSED

com.example.project.OtherTests > testThisOtherThing() PASSED

com.example.project.FirstTest > myFirstTest(TestInfo) PASSED

com.example.project.SecondTest > mySecondTest() SKIPPED
```
 

---
I hereby agree to the terms of the JUnit Contributor License Agreement.
