### PR TITLE
Update Kotlin to 1.4.30 in `junit5-jupiter-starter-gradle-kotlin` sample

### DIFF
--- a/junit5-jupiter-starter-gradle-kotlin/build.gradle.kts
+++ b/junit5-jupiter-starter-gradle-kotlin/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-	kotlin("jvm") version "1.3.31"
+	kotlin("jvm") version "1.4.30"
 }
 
 repositories {
@@ -9,7 +9,6 @@ repositories {
 }
 
 dependencies {
-	implementation(kotlin("stdlib-jdk8"))
 	testImplementation(platform("org.junit:junit-bom:5.7.1"))
 	testImplementation("org.junit.jupiter:junit-jupiter")
 }


### PR DESCRIPTION
## Overview

- Update Kotlin to 1.4.30
- Remove obslete Kotlin dependency

---
I hereby agree to the terms of the JUnit Contributor License Agreement.
