### PR TITLE
Add suite sample

### DIFF
--- a/junit5-multiple-engines/build.gradle.kts
+++ b/junit5-multiple-engines/build.gradle.kts
@@ -35,6 +35,9 @@ dependencies {
         because("allows JUnit 3 and JUnit 4 tests to run")
     }
 
+    // JUnit Suites
+    testImplementation("org.junit.platform:junit-platform-suite")
+
     // JUnit Platform Launcher + Console
     testRuntimeOnly("org.junit.platform:junit-platform-launcher") {
         because("allows tests to run from IDEs that bundle older version of launcher")

--- a/junit5-multiple-engines/src/test/java/suite/SuiteTests.java
+++ b/junit5-multiple-engines/src/test/java/suite/SuiteTests.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package suite;
+
+import org.junit.platform.suite.api.ExcludeEngines;
+import org.junit.platform.suite.api.IncludeClassNamePatterns;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.SelectPackages;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectPackages({"spock", "jqwik", "junit.jupiter", "junit.vintage", "mainrunner", "testng", "kotest", "spek"})
+@IncludeClassNamePatterns(".*((Tests?)|(Spec))$")
+@ExcludeEngines("spek") // https://github.com/spekframework/spek/issues/986
+public class SuiteTests {
+}


### PR DESCRIPTION
This PR adds the suite-engine to the `junit5-multiple-engines` sample project along with `@Suite` class. All tests (except Spek's) are executed twice for demonstration purposes.