### PR TITLE
Update Maven Surefire to 3.0.0-M6

### DIFF
--- a/junit5-jupiter-starter-maven-kotlin/pom.xml
+++ b/junit5-jupiter-starter-maven-kotlin/pom.xml
@@ -47,6 +47,13 @@
 		</dependency>
 	</dependencies>
 
+	<pluginRepositories>
+		<pluginRepository>
+			<id>staged-releases</id>
+			<url>https://repository.apache.org/content/repositories/maven-1731/</url>
+		</pluginRepository>
+	</pluginRepositories>
+
 	<build>
 		<sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
 		<testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
@@ -77,7 +84,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.2</version>
+				<version>3.0.0-M6</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/junit5-jupiter-starter-maven/pom-SNAPSHOT.xml
+++ b/junit5-jupiter-starter-maven/pom-SNAPSHOT.xml
@@ -44,6 +44,13 @@
 		</repository>
 	</repositories>
 
+	<pluginRepositories>
+		<pluginRepository>
+			<id>staged-releases</id>
+			<url>https://repository.apache.org/content/repositories/maven-1731/</url>
+		</pluginRepository>
+	</pluginRepositories>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -52,7 +59,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.2</version>
+				<version>3.0.0-M6</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/junit5-jupiter-starter-maven/pom.xml
+++ b/junit5-jupiter-starter-maven/pom.xml
@@ -33,6 +33,13 @@
 		</dependency>
 	</dependencies>
 
+	<pluginRepositories>
+		<pluginRepository>
+			<id>staged-releases</id>
+			<url>https://repository.apache.org/content/repositories/maven-1731/</url>
+		</pluginRepository>
+	</pluginRepositories>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -41,7 +48,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.2</version>
+				<version>3.0.0-M6</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/junit5-migration-maven/pom.xml
+++ b/junit5-migration-maven/pom.xml
@@ -51,11 +51,18 @@
 		</dependency>
 	</dependencies>
 
+	<pluginRepositories>
+		<pluginRepository>
+			<id>staged-releases</id>
+			<url>https://repository.apache.org/content/repositories/maven-1731/</url>
+		</pluginRepository>
+	</pluginRepositories>
+
 	<build>
 		<plugins>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.2</version>
+				<version>3.0.0-M6</version>
 				<configuration>
 					<!--<groups>fast</groups>-->
 					<excludedGroups>slow</excludedGroups>


### PR DESCRIPTION
## Overview

Test-drive Apache Maven Surefire Plugin 3.0.0-M6

---
I hereby agree to the terms of the JUnit Contributor License Agreement.
