### PR TITLE
deps: add dependabot to manage github action dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Overview

- deps: add dependabot to manage github action dependency updates

---
I hereby agree to the terms of the JUnit Contributor License Agreement.
