### PR TITLE
Upgrade Ant to `1.10.13`

### DIFF
--- a/junit5-jupiter-starter-ant/build.sh
+++ b/junit5-jupiter-starter-ant/build.sh
@@ -4,7 +4,7 @@
 # Set constants.
 #
 junit_platform_version='1.9.2'
-ant_version='1.10.11'
+ant_version='1.10.13'
 ant_folder="apache-ant-${ant_version}"
 ant_archive="${ant_folder}-bin.tar.gz"
 


### PR DESCRIPTION
## Overview

Upgrade Ant to `1.10.13`: https://lists.apache.org/thread/c2k0tnbo2l3sj8nng1r6ko2lcq35vdq4

---
I hereby agree to the terms of the JUnit Contributor License Agreement.
