### PR TITLE
Update Maven Surefire to 3.0.0-M8

### DIFF
--- a/junit5-jupiter-starter-maven-kotlin/pom.xml
+++ b/junit5-jupiter-starter-maven-kotlin/pom.xml
@@ -77,7 +77,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.0.0-M7</version>
+				<version>3.0.0-M8</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/junit5-jupiter-starter-maven/pom-SNAPSHOT.xml
+++ b/junit5-jupiter-starter-maven/pom-SNAPSHOT.xml
@@ -48,7 +48,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.0.0-M7</version>
+				<version>3.0.0-M8</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/junit5-jupiter-starter-maven/pom.xml
+++ b/junit5-jupiter-starter-maven/pom.xml
@@ -37,7 +37,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.0.0-M7</version>
+				<version>3.0.0-M8</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/junit5-migration-maven/pom.xml
+++ b/junit5-migration-maven/pom.xml
@@ -54,7 +54,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.0.0-M7</version>
+				<version>3.0.0-M8</version>
 				<configuration>
 					<!--<groups>fast</groups>-->
 					<excludedGroups>slow</excludedGroups>


### PR DESCRIPTION
## Overview

Update Maven Surefire to `3.0.0-M8`: https://maven.apache.org/surefire/maven-surefire-plugin/history.html

---
I hereby agree to the terms of the JUnit Contributor License Agreement.
