### PR TITLE
README.md: link to Apache's official repo instead of takari's one

### DIFF
--- a/junit5-jupiter-starter-maven/README.md
+++ b/junit5-jupiter-starter-maven/README.md
@@ -3,5 +3,5 @@
 The `junit5-jupiter-starter-maven` project demonstrates how to execute JUnit Jupiter
 tests using Maven.
 
-Please note that this project uses the [Maven Wrapper](https://github.com/takari/maven-wrapper).
+Please note that this project uses the [Maven Wrapper](https://github.com/apache/maven-wrapper).
 Thus, to ensure that the correct version of Maven is used, invoke `mvnw` instead of `mvn`.


### PR DESCRIPTION
Link to Apache's official repo instead of takari's one

## Overview

-

---
I hereby agree to the terms of the JUnit Contributor License Agreement.
