### PR TITLE
Bump Maven Wrapper from 3.9.0 to 3.9.1 in /junit5-jupiter-starter-maven

### DIFF
--- a/junit5-jupiter-starter-maven/.mvn/wrapper/maven-wrapper.properties
+++ b/junit5-jupiter-starter-maven/.mvn/wrapper/maven-wrapper.properties
@@ -5,14 +5,14 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-#
-#   https://www.apache.org/licenses/LICENSE-2.0
-#
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.0/apache-maven-3.9.0-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.1/apache-maven-3.9.1-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar


### PR DESCRIPTION
Bumps Maven Wrapper from 3.9.0 to 3.9.1.

Release notes of Maven 3.9.1 can be found here:
https://maven.apache.org/docs/3.9.1/release-notes.html