### PR TITLE
Bump Gradle Wrapper from 8.2 to 8.2.1 in /junit5-jupiter-starter-gradle-groovy

### DIFF
--- a/junit5-jupiter-starter-gradle-groovy/gradle/wrapper/gradle-wrapper.properties
+++ b/junit5-jupiter-starter-gradle-groovy/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=38f66cd6eef217b4c35855bb11ea4e9fbc53594ccccb5fb82dfd317ef8c2c5a3
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionSha256Sum=03ec176d388f2aa99defcadc3ac6adf8dd2bce5145a129659537c0874dea5ad1
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Bumps Gradle Wrapper from 8.2 to 8.2.1.

Release notes of Gradle 8.2.1 can be found here:
https://docs.gradle.org/8.2.1/release-notes.html