### PR TITLE
Update Gradle Test configuration to resolve deprecation warning

### DIFF
--- a/junit5-jupiter-starter-gradle-groovy/build.gradle
+++ b/junit5-jupiter-starter-gradle-groovy/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 	implementation(localGroovy())
 	testImplementation(platform('org.junit:junit-bom:5.10.1'))
 	testImplementation('org.junit.jupiter:junit-jupiter')
+	testRuntimeOnly('org.junit.platform:junit-platform-launcher')
 }
 
 test {

--- a/junit5-jupiter-starter-gradle-kotlin/build.gradle.kts
+++ b/junit5-jupiter-starter-gradle-kotlin/build.gradle.kts
@@ -11,6 +11,7 @@ repositories {
 dependencies {
 	testImplementation(platform("org.junit:junit-bom:5.10.1"))
 	testImplementation("org.junit.jupiter:junit-jupiter")
+	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 tasks.test {

--- a/junit5-jupiter-starter-gradle/build.gradle
+++ b/junit5-jupiter-starter-gradle/build.gradle
@@ -11,6 +11,7 @@ repositories {
 dependencies {
 	testImplementation(platform('org.junit:junit-bom:5.10.1'))
 	testImplementation('org.junit.jupiter:junit-jupiter')
+	testRuntimeOnly('org.junit.platform:junit-platform-launcher')
 }
 
 test {


### PR DESCRIPTION
## Overview
Current gradle builds are triggering the following warning:
```
Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.
```
See https://github.com/junit-team/junit5-samples/actions/runs/7386379862/job/20092841903
-

The current [documentation gradle guide](https://docs.gradle.org/8.5/userguide/upgrading_version_8.html) says: `If using JUnit 5, an explicit runtimeOnly dependency on junit-platform-launcher is required in addition to the existing implementation dependency on the test engine.`

---
I hereby agree to the terms of the JUnit Contributor License Agreement.
