### PR TITLE
Update TestNG to 7.10.1

### DIFF
--- a/junit5-multiple-engines/build.gradle.kts
+++ b/junit5-multiple-engines/build.gradle.kts
@@ -10,9 +10,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven {
-        url = uri("https://oss.sonatype.org/content/repositories/orgtestng-1092")
-    }
 }
 
 dependencies {

--- a/junit5-multiple-engines/build.gradle.kts
+++ b/junit5-multiple-engines/build.gradle.kts
@@ -10,6 +10,9 @@ plugins {
 
 repositories {
     mavenCentral()
+    maven {
+        url = uri("https://oss.sonatype.org/content/repositories/orgtestng-1092")
+    }
 }
 
 dependencies {
@@ -72,7 +75,7 @@ dependencies {
     }
 
     // TestNG
-    testImplementation("org.testng:testng:7.9.0") {
+    testImplementation("org.testng:testng:7.10.1") {
         because("allows writing TestNG tests")
     }
     testRuntimeOnly("org.junit.support:testng-engine:1.0.5") {


### PR DESCRIPTION
## Overview

Update to use TestNG 7.10.1

Supersedes and closes #381

---
I hereby agree to the terms of the JUnit Contributor License Agreement.
