### PR TITLE
Bump Maven Wrapper from 3.9.6 to 3.9.7

### DIFF
--- a/.github/workflows/build-all-samples.yml
+++ b/.github/workflows/build-all-samples.yml
@@ -15,3 +15,4 @@ jobs:
         run: java src/Builder.java
       - name: 'Check automation for updating versions'
         run: java src/Updater.java 42
+        if: github.repository == 'junit-team/junit5-samples' && github.ref == 'refs/heads/main'

--- a/junit5-multiple-engines/build.gradle.kts
+++ b/junit5-multiple-engines/build.gradle.kts
@@ -66,7 +66,7 @@ dependencies {
     }
 
     // Kotest
-    testImplementation("io.kotest:kotest-runner-junit5:5.8.1")
+    testImplementation("io.kotest:kotest-runner-junit5:5.9.0")
     testRuntimeOnly("org.slf4j:slf4j-nop:2.0.13") {
         because("defaulting to no-operation (NOP) logger implementation")
     }

--- a/junit5-multiple-engines/build.gradle.kts
+++ b/junit5-multiple-engines/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     groovy
     eclipse // optional (to generate Eclipse project files)
     idea // optional (to generate IntelliJ IDEA project files)
-    kotlin("jvm") version "1.9.23"
+    kotlin("jvm") version "1.9.24"
 }
 
 repositories {


### PR DESCRIPTION
# Combined PRs ➡️📦⬅️

✅ The following pull requests have been successfully combined on this PR:
- Closes #409 Bump Maven Wrapper from 3.9.6 to 3.9.7 in /junit5-migration-maven
- Closes #408 Bump Maven Wrapper from 3.9.6 to 3.9.7 in /junit5-jupiter-starter-maven
- Closes #407 Bump Maven Wrapper from 3.9.6 to 3.9.7 in /junit5-jupiter-starter-maven-kotlin

> This PR was created by the [`github/combine-prs`](https://github.com/github/combine-prs) action