### PR TITLE
Bump Gradle Wrapper from 8.7 to 8.8 in /junit5-jupiter-starter-gradle

### DIFF
--- a/junit5-jupiter-starter-gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/junit5-jupiter-starter-gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=544c35d6bd849ae8a5ed0bcea39ba677dc40f49df7d1835561582da2009b961d
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionSha256Sum=a4b4158601f8636cdeeab09bd76afb640030bb5b144aafe261a5e8af027dc612
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/junit5-jupiter-starter-gradle/gradlew
+++ b/junit5-jupiter-starter-gradle/gradlew
@@ -55,7 +55,7 @@
 #       Darwin, MinGW, and NonStop.
 #
 #   (3) This script is generated from the Groovy template
-#       https://github.com/gradle/gradle/blob/HEAD/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+#       https://github.com/gradle/gradle/blob/HEAD/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
 #       within the Gradle project.
 #
 #       You can find Gradle at https://github.com/gradle/gradle/.


### PR DESCRIPTION
Bumps Gradle Wrapper from 8.7 to 8.8.

Release notes of Gradle 8.8 can be found here:
https://docs.gradle.org/8.8/release-notes.html