### PR TITLE
Bump Maven Wrapper from 3.9.7 to 3.9.8 in /junit5-migration-maven

### DIFF
--- a/junit5-migration-maven/.mvn/wrapper/maven-wrapper.properties
+++ b/junit5-migration-maven/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.7/apache-maven-3.9.7-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.8/apache-maven-3.9.8-bin.zip


### PR DESCRIPTION
Bumps Maven Wrapper from 3.9.7 to 3.9.8.

Release notes of Maven 3.9.8 can be found here:
https://maven.apache.org/docs/3.9.8/release-notes.html